### PR TITLE
Consistent linking of ChemicalMixtureType

### DIFF
--- a/schemas/chemicalMixture.schema.tpl.json
+++ b/schemas/chemicalMixture.schema.tpl.json
@@ -29,7 +29,7 @@
     },
     "type": {
       "_instruction": "Add the type of the mixture.",
-      "_embeddedTypes": [
+      "_linkedTypes": [
         "https://openminds.ebrains.eu/controlledTerms/ChemicalMixtureType"
       ]
     }


### PR DESCRIPTION
ChemicalMixtureType is linked everywhere else it is used, it is only embedded in ChemicalMixture. Changing it to linked everywhere, for consistency.